### PR TITLE
Add non cacheable tasks metric

### DIFF
--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/metric/BuildMetric.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/metric/BuildMetric.kt
@@ -81,6 +81,9 @@ data class BuildMetric(
     @Json(name = "dependency_details_metric")
     var dependencyDetailsMetric: DependencyDetailsMetric? = null,
 
+    @Json(name = "non_cacheable_tasks_metric")
+    var nonCacheableTasksMetric: NonCacheableTasksMetric? = null,
+
 ): java.io.Serializable {
 
     @Transient

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/metric/NonCacheableTasksMetric.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/metric/NonCacheableTasksMetric.kt
@@ -1,0 +1,42 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.domain.model.metric
+
+import com.squareup.moshi.JsonClass
+import io.github.janbarari.gradle.ExcludeJacocoGenerated
+import java.io.Serializable
+
+@ExcludeJacocoGenerated
+@JsonClass(generateAdapter = true)
+data class NonCacheableTasksMetric(
+    val tasks: List<NonCacheableTask>
+): Serializable {
+
+    @ExcludeJacocoGenerated
+    @JsonClass(generateAdapter = true)
+    data class NonCacheableTask(
+        val path: String,
+        var avgExecutionDurationInMillis: Long
+    ): Serializable
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/report/NonCacheableTasksReport.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/report/NonCacheableTasksReport.kt
@@ -20,44 +20,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package io.github.janbarari.gradle.analytics.domain.model
+package io.github.janbarari.gradle.analytics.domain.model.report
 
-import org.gradle.tooling.Failure
-import org.gradle.tooling.events.OperationDescriptor
+import com.squareup.moshi.JsonClass
+import io.github.janbarari.gradle.ExcludeJacocoGenerated
+import io.github.janbarari.gradle.analytics.domain.model.metric.NonCacheableTasksMetric
+import java.io.Serializable
 
-data class TaskInfo(
-    val startedAt: Long,
-    val finishedAt: Long,
-    val path: String,
-    val displayName: String,
-    val name: String,
-    val isSuccessful: Boolean,
-    val failures: List<Failure>?,
-    val dependencies: List<OperationDescriptor>?,
-    val isIncremental: Boolean,
-    val isFromCache: Boolean,
-    val isUpToDate: Boolean,
-    val isSkipped: Boolean,
-    val executionReasons: List<String>?
-) : java.io.Serializable {
-
-    /**
-     * Returns the task execution duration in milliseconds.
-     */
-    fun getDurationInMillis(): Long {
-        if (finishedAt < startedAt) return 0L
-        return finishedAt - startedAt
-    }
-
-    /**
-     * Returns the task module name.
-     */
-    fun getModule(): String {
-        val module = path.split(":")
-        return if (module.size > 2) module.toList()
-            .dropLast(1)
-            .joinToString(separator = ":")
-        else "no_module"
-    }
-
-}
+@ExcludeJacocoGenerated
+@JsonClass(generateAdapter = true)
+data class NonCacheableTasksReport(
+    val tasks: List<NonCacheableTasksMetric.NonCacheableTask>
+): Serializable

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/report/Report.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/model/report/Report.kt
@@ -84,6 +84,9 @@ data class Report(
     @Json(name = "dependency_details_report")
     var dependencyDetailsReport: DependencyDetailsReport? = null,
 
+    @Json(name = "non_cacheable_tasks_report")
+    var nonCacheableTasksReport: NonCacheableTasksReport? = null,
+
 ) : java.io.Serializable {
 
     fun toJson(): String {

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/usecase/SaveMetricUseCase.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/domain/usecase/SaveMetricUseCase.kt
@@ -48,6 +48,8 @@ import io.github.janbarari.gradle.analytics.metric.modulesmethodcount.update.Upd
 import io.github.janbarari.gradle.analytics.metric.modulesmethodcount.update.UpdateModulesMethodCountMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.update.UpdateModulesSourceCountMetricStage
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.update.UpdateModulesSourceCountMetricUseCase
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.update.UpdateNonCacheableTasksMetricStage
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.update.UpdateNonCacheableTasksMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.update.UpdateParallelExecutionRateMetricStage
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.update.UpdateParallelExecutionRateMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.overallbuildprocess.update.UpdateOverallBuildProcessMetricStage
@@ -72,7 +74,8 @@ class SaveMetricUseCase(
     private val updateModulesExecutionProcessMetricUseCase: UpdateModulesExecutionProcessMetricUseCase,
     private val updateModulesDependencyGraphMetricUseCase: UpdateModulesDependencyGraphMetricUseCase,
     private val updateModulesBuildHeatmapMetricUseCase: UpdateModulesBuildHeatmapMetricUseCase,
-    private val updateDependencyDetailsMetricUseCase: UpdateDependencyDetailsMetricUseCase
+    private val updateDependencyDetailsMetricUseCase: UpdateDependencyDetailsMetricUseCase,
+    private val updateNonCacheableTasksMetricUseCase: UpdateNonCacheableTasksMetricUseCase
 ) : UseCase<BuildMetric, Long>() {
 
     /**
@@ -109,6 +112,9 @@ class SaveMetricUseCase(
             val updateDependencyDetailsMetricStage = UpdateDependencyDetailsMetricStage(
                 updateDependencyDetailsMetricUseCase
             )
+            val updateNonCacheableTasksMetricStage = UpdateNonCacheableTasksMetricStage(
+                updateNonCacheableTasksMetricUseCase
+            )
 
             val updatedMetric = UpdateMetricPipeline(updateInitializationProcessMetricStage)
                 .addStage(updateConfigurationProcessMetricStage)
@@ -124,6 +130,7 @@ class SaveMetricUseCase(
                 .addStage(updateModulesDependencyGraphMetricStage)
                 .addStage(updateModulesBuildHeatmapMetricStage)
                 .addStage(updateDependencyDetailsMetricStage)
+                .addStage(updateNonCacheableTasksMetricStage)
                 .execute(BuildMetric(input.branch, input.requestedTasks, input.createdAt))
 
             val dayMetricNumber = repo.getDayMetric().second

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/modulesexecutionprocess/create/CreateModulesExecutionProcessMetricUseCase.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/modulesexecutionprocess/create/CreateModulesExecutionProcessMetricUseCase.kt
@@ -43,7 +43,7 @@ class CreateModulesExecutionProcessMetricUseCase: UseCase<Pair<List<ModulePath>,
             val tasks = buildInfo.executedTasks.filter { it.path.startsWith(path) }
 
             val overallDuration = buildInfo.getExecutionDuration().toMillis()
-            val moduleParallelDuration = tasks.sumOf { it.getDuration() }
+            val moduleParallelDuration = tasks.sumOf { it.getDurationInMillis() }
             val moduleNonParallelDuration = calculateNonParallelExecutionDuration(tasks)
             val moduleParallelRate = (moduleParallelDuration - moduleNonParallelDuration)
                 .toPercentageOf(moduleNonParallelDuration)

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/create/CreateNonCacheableTasksMetricStage.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/create/CreateNonCacheableTasksMetricStage.kt
@@ -1,0 +1,42 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.create
+
+import io.github.janbarari.gradle.analytics.domain.model.BuildInfo
+import io.github.janbarari.gradle.analytics.domain.model.metric.BuildMetric
+import io.github.janbarari.gradle.core.Stage
+
+class CreateNonCacheableTasksMetricStage(
+    private val buildInfo: BuildInfo,
+    private val createNonCacheableTasksMetricUseCase: CreateNonCacheableTasksMetricUseCase
+): Stage<BuildMetric, BuildMetric> {
+
+    override suspend fun process(buildMetric: BuildMetric): BuildMetric {
+        return buildMetric.apply {
+            if (buildInfo.isSuccessful) {
+                nonCacheableTasksMetric = createNonCacheableTasksMetricUseCase.execute(buildInfo)
+            }
+        }
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/create/CreateNonCacheableTasksMetricUseCase.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/create/CreateNonCacheableTasksMetricUseCase.kt
@@ -1,0 +1,55 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.create
+
+import io.github.janbarari.gradle.analytics.domain.model.BuildInfo
+import io.github.janbarari.gradle.analytics.domain.model.metric.NonCacheableTasksMetric
+import io.github.janbarari.gradle.core.UseCase
+import io.github.janbarari.gradle.extension.whenEach
+
+class CreateNonCacheableTasksMetricUseCase(
+    private val nonCacheableTasks: List<String>
+): UseCase<BuildInfo, NonCacheableTasksMetric>() {
+
+    override suspend fun execute(buildInfo: BuildInfo): NonCacheableTasksMetric {
+        val executedTasks = buildInfo.executedTasks
+        val temp = mutableListOf<NonCacheableTasksMetric.NonCacheableTask>()
+
+        nonCacheableTasks.whenEach {
+            executedTasks.filter { it.path == this }
+                .forEach { task ->
+                    temp.add(
+                        NonCacheableTasksMetric.NonCacheableTask(
+                            path = task.path,
+                            avgExecutionDurationInMillis = task.getDurationInMillis()
+                        )
+                    )
+                }
+        }
+
+        return NonCacheableTasksMetric(
+            tasks = temp
+        )
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/render/CreateNonCacheableTasksReportStage.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/render/CreateNonCacheableTasksReportStage.kt
@@ -1,0 +1,60 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.render
+
+import io.github.janbarari.gradle.analytics.domain.model.metric.BuildMetric
+import io.github.janbarari.gradle.analytics.domain.model.report.NonCacheableTasksReport
+import io.github.janbarari.gradle.analytics.domain.model.report.Report
+import io.github.janbarari.gradle.core.Stage
+import io.github.janbarari.gradle.extension.isBigger
+import io.github.janbarari.gradle.extension.isNotNull
+import io.github.janbarari.gradle.extension.modify
+import io.github.janbarari.gradle.utils.MathUtils
+
+class CreateNonCacheableTasksReportStage(
+    private val metrics: List<BuildMetric>
+): Stage<Report, Report> {
+
+    override suspend fun process(report: Report): Report {
+        return report.apply {
+            val tasks = metrics.last().nonCacheableTasksMetric?.tasks
+                ?.modify {
+                    val medianValue = metrics
+                        .filter { it.nonCacheableTasksMetric.isNotNull() }
+                        .flatMap { metric ->
+                            metric.nonCacheableTasksMetric!!.tasks
+                                .filter { it.path == path }
+                                .map { it.avgExecutionDurationInMillis }
+                        }
+                    avgExecutionDurationInMillis = MathUtils.longMedian(medianValue)
+                }
+                ?.filter { it.avgExecutionDurationInMillis.isBigger(0) }
+                ?: emptyList()
+
+            nonCacheableTasksReport = NonCacheableTasksReport(
+                tasks = tasks
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/render/RenderNonCacheableTasksReportStage.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/render/RenderNonCacheableTasksReportStage.kt
@@ -1,0 +1,98 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.render
+
+import io.github.janbarari.gradle.analytics.domain.model.report.Report
+import io.github.janbarari.gradle.core.Stage
+import io.github.janbarari.gradle.extension.isNull
+import io.github.janbarari.gradle.extension.toArrayString
+import io.github.janbarari.gradle.extension.whenEach
+import io.github.janbarari.gradle.extension.whenNotNull
+import io.github.janbarari.gradle.utils.HtmlUtils
+
+class RenderNonCacheableTasksReportStage(
+    private val report: Report
+): Stage<String, String> {
+
+    companion object {
+        private const val NON_CACHEABLE_TASKS_METRIC_TEMPLATE_ID = "%non-cacheable-tasks-metric%"
+        private const val NON_CACHEABLE_TASKS_METRIC_TEMPLATE_FILENAME = "non-cacheable-tasks-metric-template"
+    }
+
+    override suspend fun process(input: String): String {
+        if (report.nonCacheableTasksReport.isNull())
+            return input.replace(NON_CACHEABLE_TASKS_METRIC_TEMPLATE_ID, getEmptyRender())
+
+        return input.replace(NON_CACHEABLE_TASKS_METRIC_TEMPLATE_ID, getMetricRender())
+    }
+
+    fun getEmptyRender(): String {
+        return HtmlUtils.renderMessage("Non-cacheable Tasks is not available!")
+    }
+
+    fun getMetricRender(): String {
+        var renderedTemplate = HtmlUtils.getTemplate(NON_CACHEABLE_TASKS_METRIC_TEMPLATE_FILENAME)
+        report.nonCacheableTasksReport.whenNotNull {
+            val labels = mutableListOf<String>()
+            val colors = mutableListOf<String>()
+            val dataset = mutableListOf<Long>()
+
+            tasks.sortedByDescending { it.avgExecutionDurationInMillis }
+                .whenEach {
+                    labels.add(path)
+                    colors.add(getRandomColor())
+                    dataset.add(avgExecutionDurationInMillis)
+                }
+
+            val chartHeight = dataset.size * 36
+
+            renderedTemplate = renderedTemplate
+                .replace("%labels%", labels.toArrayString())
+                .replace("%colors%", colors.toArrayString())
+                .replace("%dataset%", dataset.toString())
+                .replace("%chart-height%", "${chartHeight}px")
+        }
+        return renderedTemplate
+    }
+
+    fun getRandomColor(): String {
+        val colors = listOf(
+            "#3b76af",
+            "#b3c6e5",
+            "#ef8536",
+            "#f5bd82",
+            "#519d3e",
+            "#a8dc93",
+            "#c53a32",
+            "#f19d99",
+            "#8d6ab8",
+            "#c2b1d2",
+            "#84584e",
+            "#be9e96",
+            "#d57ebe",
+            "#c2cd30"
+        )
+        return colors[colors.indices.random() % colors.size]
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/update/UpdateNonCacheableTasksMetricStage.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/update/UpdateNonCacheableTasksMetricStage.kt
@@ -1,0 +1,38 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.update
+
+import io.github.janbarari.gradle.analytics.domain.model.metric.BuildMetric
+import io.github.janbarari.gradle.core.Stage
+
+class UpdateNonCacheableTasksMetricStage(
+    private val updateNonCacheableTasksMetricUseCase: UpdateNonCacheableTasksMetricUseCase
+): Stage<BuildMetric, BuildMetric> {
+
+    override suspend fun process(input: BuildMetric): BuildMetric {
+        return input.apply {
+            nonCacheableTasksMetric = updateNonCacheableTasksMetricUseCase.execute()
+        }
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/update/UpdateNonCacheableTasksMetricUseCase.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/noncacheabletasks/update/UpdateNonCacheableTasksMetricUseCase.kt
@@ -1,0 +1,54 @@
+/**
+ * MIT License
+ * Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.github.janbarari.gradle.analytics.metric.noncacheabletasks.update
+
+import io.github.janbarari.gradle.analytics.domain.model.metric.NonCacheableTasksMetric
+import io.github.janbarari.gradle.analytics.domain.repository.DatabaseRepository
+import io.github.janbarari.gradle.core.UseCaseNoInput
+import io.github.janbarari.gradle.extension.isNotNull
+import io.github.janbarari.gradle.extension.modify
+import io.github.janbarari.gradle.utils.MathUtils
+
+class UpdateNonCacheableTasksMetricUseCase(
+    private val repo: DatabaseRepository
+) : UseCaseNoInput<NonCacheableTasksMetric>() {
+
+    override suspend fun execute(): NonCacheableTasksMetric {
+        val tasks = repo.getTemporaryMetrics().last().nonCacheableTasksMetric!!.tasks
+            .modify {
+                val medianValue = repo.getTemporaryMetrics()
+                    .filter { it.nonCacheableTasksMetric.isNotNull() }
+                    .flatMap {
+                        it.nonCacheableTasksMetric!!.tasks
+                            .filter { it.path == path }
+                            .map { it.avgExecutionDurationInMillis }
+                    }
+                avgExecutionDurationInMillis = MathUtils.longMedian(medianValue)
+            }
+
+        return NonCacheableTasksMetric(
+            tasks = tasks
+        )
+    }
+
+}

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/paralleexecutionrate/create/CreateParallelExecutionRateMetricUseCase.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/metric/paralleexecutionrate/create/CreateParallelExecutionRateMetricUseCase.kt
@@ -126,7 +126,7 @@ class CreateParallelExecutionRateMetricUseCase : UseCase<BuildInfo, ParallelExec
     }
 
     fun getParallelExecutionDuration(executedTasks: Collection<TaskInfo>): Long {
-        return executedTasks.sumOf { it.getDuration() }
+        return executedTasks.sumOf { it.getDurationInMillis() }
     }
 
 }

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/reporttask/ReportAnalyticsLogicImp.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/reporttask/ReportAnalyticsLogicImp.kt
@@ -54,6 +54,8 @@ import io.github.janbarari.gradle.analytics.metric.modulesourcecount.report.Crea
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.report.RenderModulesSourceCountStage
 import io.github.janbarari.gradle.analytics.metric.modulestimeline.render.CreateModulesTimelineReportStage
 import io.github.janbarari.gradle.analytics.metric.modulestimeline.render.RenderModulesTimelineReportStage
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.render.CreateNonCacheableTasksReportStage
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.render.RenderNonCacheableTasksReportStage
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.report.CreateParallelExecutionRateReportStage
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.report.RenderParallelExecutionRateReportStage
 import io.github.janbarari.gradle.analytics.metric.overallbuildprocess.report.CreateOverallBuildProcessReportStage
@@ -106,6 +108,7 @@ class ReportAnalyticsLogicImp(
             .addStage(CreateBuildStatusReportStage(modulesPath, data))
             .addStage(CreateModulesBuildHeatmapReportStage(data))
             .addStage(CreateDependencyDetailsReportStage(data))
+            .addStage(CreateNonCacheableTasksReportStage(data))
             .execute(
                 Report(
                     branch = branch,
@@ -140,6 +143,7 @@ class ReportAnalyticsLogicImp(
         val renderBuildStatusReportStage = RenderBuildStatusReportStage(report)
         val renderModulesBuildHeatmapReportStage = RenderModulesBuildHeatmapReportStage(report)
         val renderDependencyDetailsReportStage = RenderDependencyDetailsReportStage(report)
+        val renderNonCacheableTasksReportStage = RenderNonCacheableTasksReportStage(report)
 
         return RenderReportPipeline(renderInitialReportStage)
             .addStage(renderInitializationProcessReportStage)
@@ -158,6 +162,7 @@ class ReportAnalyticsLogicImp(
             .addStage(renderBuildStatusReportStage)
             .addStage(renderModulesBuildHeatmapReportStage)
             .addStage(renderDependencyDetailsReportStage)
+            .addStage(renderNonCacheableTasksReportStage)
             .execute(rawHTML)
     }
 

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/scanner/execution/BuildExecutionInjector.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/scanner/execution/BuildExecutionInjector.kt
@@ -59,6 +59,8 @@ import io.github.janbarari.gradle.analytics.metric.modulesmethodcount.update.Upd
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.create.CreateModulesSourceCountMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.update.UpdateModulesSourceCountMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.modulestimeline.create.CreateModulesTimelineMetricUseCase
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.create.CreateNonCacheableTasksMetricUseCase
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.update.UpdateNonCacheableTasksMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.create.CreateParallelExecutionRateMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.update.UpdateParallelExecutionRateMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.overallbuildprocess.create.CreateOverallBuildProcessMetricUseCase
@@ -174,6 +176,11 @@ fun BuildExecutionInjector.provideUpdateDependencyDetailsMetricUseCase(): Update
 }
 
 @ExcludeJacocoGenerated
+fun BuildExecutionInjector.provideUpdateNonCacheableTasksMetricUseCase(): UpdateNonCacheableTasksMetricUseCase {
+    return UpdateNonCacheableTasksMetricUseCase(provideDatabaseRepository())
+}
+
+@ExcludeJacocoGenerated
 fun BuildExecutionInjector.provideSaveMetricUseCase(): SaveMetricUseCase {
     return SaveMetricUseCase(
         provideDatabaseRepository(),
@@ -190,7 +197,8 @@ fun BuildExecutionInjector.provideSaveMetricUseCase(): SaveMetricUseCase {
         provideUpdateModulesExecutionProcessMetricUseCase(),
         provideUpdateModulesDependencyGraphMetricUseCase(),
         provideUpdateModulesBuildHeatmapMetricUseCase(),
-        provideUpdateDependencyDetailsMetricUseCase()
+        provideUpdateDependencyDetailsMetricUseCase(),
+        provideUpdateNonCacheableTasksMetricUseCase()
     )
 }
 
@@ -283,6 +291,11 @@ fun BuildExecutionInjector.provideCreateDependencyDetailsMetricUseCase(): Create
 }
 
 @ExcludeJacocoGenerated
+fun BuildExecutionInjector.provideCreateNonCacheableTasksMetricUseCase(): CreateNonCacheableTasksMetricUseCase {
+    return CreateNonCacheableTasksMetricUseCase(nonCachableTasks!!)
+}
+
+@ExcludeJacocoGenerated
 fun BuildExecutionInjector.provideBuildExecutionLogic(): BuildExecutionLogic {
     return BuildExecutionLogicImp(
         provideSaveMetricUseCase(),
@@ -303,6 +316,7 @@ fun BuildExecutionInjector.provideBuildExecutionLogic(): BuildExecutionLogic {
         provideCreateModulesTimelineMetricUseCase(),
         provideCreateModulesBuildHeatmapMetricUseCase(),
         provideCreateDependencyDetailsMetricUseCase(),
+        provideCreateNonCacheableTasksMetricUseCase(),
         ensureNotNull(databaseConfig),
         ensureNotNull(isCI),
         ensureNotNull(trackingBranches),

--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/scanner/execution/BuildExecutionLogicImp.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/scanner/execution/BuildExecutionLogicImp.kt
@@ -61,6 +61,8 @@ import io.github.janbarari.gradle.analytics.metric.modulesourcecount.create.Crea
 import io.github.janbarari.gradle.analytics.metric.modulesourcecount.create.CreateModulesSourceCountMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.modulestimeline.create.CreateModulesTimelineMetricStage
 import io.github.janbarari.gradle.analytics.metric.modulestimeline.create.CreateModulesTimelineMetricUseCase
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.create.CreateNonCacheableTasksMetricStage
+import io.github.janbarari.gradle.analytics.metric.noncacheabletasks.create.CreateNonCacheableTasksMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.create.CreateParallelExecutionRateMetricStage
 import io.github.janbarari.gradle.analytics.metric.paralleexecutionrate.create.CreateParallelExecutionRateMetricUseCase
 import io.github.janbarari.gradle.analytics.metric.overallbuildprocess.create.CreateOverallBuildProcessMetricStage
@@ -101,6 +103,7 @@ class BuildExecutionLogicImp(
     private val createModulesTimelineMetricUseCase: CreateModulesTimelineMetricUseCase,
     private val createModulesBuildHeatmapMetricUseCase: CreateModulesBuildHeatmapMetricUseCase,
     private val createDependencyDetailsMetricUseCase: CreateDependencyDetailsMetricUseCase,
+    private val createNonCacheableTasksMetricUseCase: CreateNonCacheableTasksMetricUseCase,
     private val databaseConfig: DatabaseConfig,
     private val envCI: Boolean,
     private val trackingBranches: List<String>,
@@ -180,6 +183,10 @@ class BuildExecutionLogicImp(
             dependencies,
             createDependencyDetailsMetricUseCase
         )
+        val createNonCacheableTasksMetricStage = CreateNonCacheableTasksMetricStage(
+            info,
+            createNonCacheableTasksMetricUseCase
+        )
 
         val buildMetric = CreateMetricPipeline(createInitializationProcessMetricStage)
             .addStage(createConfigurationProcessMetricStage)
@@ -196,6 +203,7 @@ class BuildExecutionLogicImp(
             .addStage(createModulesTimelineMetricStage)
             .addStage(createModulesBuildHeatmapMetricStage)
             .addStage(createDependencyDetailsMetricStage)
+            .addStage(createNonCacheableTasksMetricStage)
             .execute(BuildMetric(info.branch, info.requestedTasks, info.createdAt))
 
         saveTemporaryMetricUseCase.execute(buildMetric)

--- a/src/main/resources/index-template.html
+++ b/src/main/resources/index-template.html
@@ -68,6 +68,8 @@
 
     %dependency-details-metric%
 
+    %non-cacheable-tasks-metric%
+
     <div class="space"></div>
     <img src="res/plugin-logo.png" class="footer-logo" alt="logo" />
     <span class="footer-text"><b><a href="https://github.com/janbarari/gradle-analytics-plugin" target="_blank">Gradle Analytics Plugin</a></b></span>

--- a/src/main/resources/non-cacheable-tasks-metric-template.html
+++ b/src/main/resources/non-cacheable-tasks-metric-template.html
@@ -1,0 +1,43 @@
+<h2>Non-cacheable Tasks</h2>
+<p class="gray-text pb16">This is a description.</p>
+<div class="chart-container" style="margin-right: 20px; height: %chart-height%;">
+  <canvas id="nonCacheableTasksChart" style="width:100%; height: 100%;"></canvas>
+  <script type="text/javascript">
+    var chart = new Chart("nonCacheableTasksChart", {
+      type: "bar",
+      data: {
+        labels: %labels%,
+        datasets: [
+          {
+            backgroundColor: %colors%,
+            data: %dataset%
+          }
+        ]
+      },
+      options: {
+        indexAxis: 'y',
+        maintainAspectRatio: false,
+        plugins: {
+          legend: {
+            display: false
+          },
+          tooltip: {
+            mode: 'index',
+            axis: 'y',
+            intersect: false,
+            callbacks: {
+              label: function (context) {
+                let label = context.dataset.label || '';
+                return " " + context.parsed.x + "ms";
+              }
+            }
+          }
+        }
+      }
+    });
+  </script>
+</div>
+<span class="gray-text center-text">
+  <span>Smaller Bars Are Better</span>
+</span>
+<div class="space"></div>

--- a/src/test/kotlin/io/github/janbarari/gradle/analytics/domain/model/TaskInfoTest.kt
+++ b/src/test/kotlin/io/github/janbarari/gradle/analytics/domain/model/TaskInfoTest.kt
@@ -22,7 +22,7 @@ class TaskInfoTest {
             false,
             null
         )
-        assertEquals(49, task.getDuration())
+        assertEquals(49, task.getDurationInMillis())
     }
 
     @Test
@@ -66,7 +66,7 @@ class TaskInfoTest {
             false,
             null
         )
-        assertEquals(0, task.getDuration())
+        assertEquals(0, task.getDurationInMillis())
     }
 
     @Test


### PR DESCRIPTION
<!-- Enter the issue number(ex: Issue-1) or task number(ex: R-8, F-1) -->
> F-43

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Non-cacheable tasks are not good in the build process. Because these tasks are not cached locally or remotely and must be executed each time, it is good that the developers know how many non-cacheable tasks their Gradle process has and how long it takes to execute.

### Description
<!-- Summarize the change and help the reviewer on important points -->
Only those non-cacheable tasks will be listed when they exist in that executed in the build process.

### Type of change
<!-- Choose the PR type, you can choose multiple types -->
- [x] Feature
- [ ] POC
- [ ] Bug fix
- [ ] Hot fix
- [ ] Optimization
- [ ] Refactor
- [ ] Noref

### Checklist
- [x] Are local unit tests passed?
- [x] Is Detekt passed?
- [x] Is code coverage affected?
- [ ] Is any new test added?
- [ ] Is CI workflow affected?
- [x] Is a next refactor needed?

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

### Screenshots
<!-- Please put the screenshots here if it's exists -->
<!-- Use this template to scale down big images. -->
<!-- You'll get the link after image upload with Drag & Drop -->
<img src="https://user-images.githubusercontent.com/12547060/188804330-9067e141-0d8d-443d-8215-62f7c9c343b8.png" width=70% height=70%> 
