### PR TITLE
B-72/Increase project stability

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,17 @@
+comment: false
+
 codecov:
   require_ci_to_pass: yes
   notify:
     wait_for_ci: yes
 
 coverage:
-  precision: 2
+  range: 60...90
   round: down
-  range: 65...100
+  precision: 2
+
+  status:
+    project:
+      default:
+        target: 60%
+        threshold: 0%

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ codecov:
 coverage:
   precision: 2
   round: down
-  range: 39...100
+  range: 65...100


### PR DESCRIPTION
<!-- Enter the issue number(ex: Issue-1) or task number(ex: R-8, F-1) -->
> B-72

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Setting codecov target to 60% will increase the project's stability.

### Type of change
<!-- Choose the PR type, you can choose multiple types -->
- [ ] Feature
- [ ] POC
- [x] Bug fix
- [ ] Hot fix
- [ ] Optimization
- [ ] Refactor
- [ ] Noref

### Checklist
- [x] Are local unit tests passed?
- [x] Is Detekt passed?
- [x] Is code coverage affected?
- [ ] Is any new test added?
- [ ] Is CI workflow affected?
- [ ] Is a next refactor needed?
