### PR TITLE
fix(77): disable the task output on incremental builds

### DIFF
--- a/src/main/kotlin/io/github/janbarari/gradle/analytics/reporttask/ReportAnalyticsTask.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/analytics/reporttask/ReportAnalyticsTask.kt
@@ -65,7 +65,9 @@ abstract class ReportAnalyticsTask : DefaultTask() {
                     trackingTasksProperty.set(config.trackingTasks)
                     trackingBranchesProperty.set(config.trackingBranches)
                     databaseConfigProperty.set(config.getDatabaseConfig())
+                    // disable the task from being cached or reuse the outputs on incremental builds.
                     outputs.cacheIf { false }
+                    outputs.upToDateWhen { false }
                 }
             }
         }


### PR DESCRIPTION
<!--
 MIT License
 Copyright (c) 2022 Mehdi Janbarari (@janbarari)

 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:

 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-->

<!-- Enter the issue number(ex: Issue-1) or task number(ex: R-8, F-1) -->
> Fix-77

### Description
Currently, the report task is not cacheable but, It will be upToDate when incremental builds happened. Fix it to always execute the task.

### Type of change
<!-- Choose the PR type, you can choose multiple types -->
- [ ] Feature
- [ ] POC
- [x] Bug fix
- [ ] Hot fix
- [ ] Optimization
- [ ] Refactor
- [ ] Noref
- [ ] Test

### Checklist
- [x] Are local unit tests passed?
- [x] Is Detekt passed?
- [ ] Is code coverage affected?
- [ ] Is any new test added?
- [ ] Is CI workflow affected?
- [ ] Is a next refactor needed?
