### PR TITLE
noref(78): upgrade Gradle version to 7.6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -21,6 +21,6 @@
 
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/io/github/janbarari/gradle/utils/ProjectUtils.kt
+++ b/src/main/kotlin/io/github/janbarari/gradle/utils/ProjectUtils.kt
@@ -33,6 +33,7 @@ object ProjectUtils {
      * List of official Gradle versions.
      */
     enum class GradleVersions(val versionNumber: String) {
+        V7_6("7.6"),
         V7_5_1("7.5.1"),
         V7_5("7.5"),
         V7_4_2("7.4.2"),

--- a/src/test/kotlin/io/github/janbarari/gradle/utils/ProjectUtilsTest.kt
+++ b/src/test/kotlin/io/github/janbarari/gradle/utils/ProjectUtilsTest.kt
@@ -35,7 +35,7 @@ class ProjectUtilsTest {
 
     @Test
     fun `check isCompatibleWith() returns true when the version is before 7_5`() {
-        val result = ProjectUtils.isCompatibleWith(ProjectUtils.GradleVersions.V7_5)
+        val result = ProjectUtils.isCompatibleWith(ProjectUtils.GradleVersions.V7_6)
         assertEquals(false, result)
     }
 


### PR DESCRIPTION
<!--
 MIT License
 Copyright (c) 2022 Mehdi Janbarari (@janbarari)

 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:

 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-->

<!-- Enter the issue number(ex: Issue-1) or task number(ex: R-8, F-1) -->
> Noref-78

### Changelog
Gradle version was upgraded to 7.6

### Type of change
<!-- Choose the PR type, you can choose multiple types -->
- [ ] Feature
- [ ] POC
- [ ] Bug fix
- [ ] Hot fix
- [ ] Optimization
- [ ] Refactor
- [x] Noref
- [ ] Test

### Checklist
- [x] Are local unit tests passed?
- [x] Is Detekt passed?
- [ ] Is code coverage affected?
- [x] Is any new test added?
- [ ] Is CI workflow affected?
- [ ] Is a next refactor needed?