### PR TITLE
noref(92): Add `upcoming-milestone` and `social-press` in the docs

### DIFF
--- a/docs/social-press.md
+++ b/docs/social-press.md
@@ -1,0 +1,30 @@
+<!--
+ MIT License
+ Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+# Social
+It's my pleasure that Gradle Analytics Plugin has been introduced in the below links:
+
+- [Gradle Newsletter (Oct 2022)](https://newsletter.gradle.org/2022/10)
+- [Open Source Agenda](https://www.opensourceagenda.com/tags/gradle-plugins)
+- [Awesome Open Source](https://awesomeopensource.com/project/janbarari/gradle-analytics-plugin)
+

--- a/docs/upcoming-milestone.md
+++ b/docs/upcoming-milestone.md
@@ -1,0 +1,33 @@
+<!--
+ MIT License
+ Copyright (c) 2022 Mehdi Janbarari (@janbarari)
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+-->
+
+# Upcoming Milestone
+Upcoming milestone planned to be delivered in the first week of March 2023.
+
+Tasks:
+
+- [x] Add `upcoming-milestone`, `social-press` in documentation
+- [ ] [Request Feature 81](https://github.com/janbarari/gradle-analytics-plugin/issues/81)
+- [ ] Add used workers count and max workers count in the report analytics
+- [ ] Add more logs in the `build logger` and `report logger`
+

--- a/docs/upcoming-milestone.md
+++ b/docs/upcoming-milestone.md
@@ -30,4 +30,3 @@ Tasks:
 - [ ] [Request Feature 81](https://github.com/janbarari/gradle-analytics-plugin/issues/81)
 - [ ] Add used workers count and max workers count in the report analytics
 - [ ] Add more logs in the `build logger` and `report logger`
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,8 @@ nav:
   - Third party: third-party.md
   - License: license.md
   - Community: community.md
+  - Social/Press: social-press.md
+  - Upcoming Milestone: upcoming-milestone.md
 
 theme:
   name: material
@@ -69,6 +71,8 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
 
 copyright: Made with 🧡 for everyone | Copyright &copy; 2022
 


### PR DESCRIPTION
<!--
 MIT License
 Copyright (c) 2022 Mehdi Janbarari (@janbarari)

 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
 to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:

 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-->

<!-- Enter the issue number(ex: Issue-1) or task number(ex: R-8, F-1) -->
> Noref-92

### Changelog
<!-- Summarize the changes -->
- `upcoming-milestone.md` added
- `social-press` added