### PR TITLE
Optimize usage of version catalog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,13 +37,13 @@ val pluginTags: String by project
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    kotlin("jvm") version libs.versions.kotlin
+    alias(libs.plugins.kotlin)
     alias(libs.plugins.detekt)
     `java-gradle-plugin`
     `maven-publish`
     jacoco
-    id("com.google.devtools.ksp") version libs.versions.ksp
-    id("com.gradle.plugin-publish") version libs.versions.publish.plugin
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.publish)
 }
 
 group = pluginGroupPackageName

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
 
     compileOnly(gradleApi())
 
-    implementation(kotlin("stdlib-jdk8"))
     implementation(libs.sqlite.driver)
     implementation(libs.mysql.driver)
     implementation(libs.postgres.driver)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,3 +48,6 @@ coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", ve
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+publish = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin" }


### PR DESCRIPTION
### Related Issue
<!--- If it fixes an open issue, please link to the issue here. -->
n/a

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This just aligned the usage of the version catalog in regards of Gradle plugins.
Nothing fancy, just a small clean up 🙃 

### Description
<!-- Help the reviewer on important points -->
I not only cleaned up the version catalog usage but also removed the jdk dependency of kotlin.
This wil automatically added by the plugin. No need for it.

### Changelog
<!-- Summarize the changes -->
* Clean up usage of version catalog

### Type of change
<!-- Choose the PR type, you can choose multiple types -->
- [ ] Feature
- [ ] POC
- [ ] Bug fix
- [ ] Hot fix
- [x] Optimization
- [x] Refactor
- [ ] Noref
- [ ] Test

### Checklist
- [x] Are local unit tests passed?
- [x] Is Detekt passed?
- [ ] Is code coverage affected?
- [ ] Is any new test added?
- [ ] Is CI workflow affected?
- [ ] Is a next refactor needed?

### How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I just run the same thing as on CI:
```bash
./gradlew clean validateSourceHeaderLicense detekt assemble test --info --stacktrace
```

### Screenshots
<!-- Please put the screenshots here if it's exists -->
<!-- Use this template to scale down big images. -->
<!-- You'll get the link after image upload with Drag & Drop -->
<!-- <img src="https://img.png" width=45% height=45%> -->
n/a